### PR TITLE
Update to play 2.3 and bumped version to 2.3.0-RC1

### DIFF
--- a/app/be/objectify/deadbolt/scala/DeadboltHandler.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltHandler.scala
@@ -1,6 +1,6 @@
 package be.objectify.deadbolt.scala
 
-import play.api.mvc.{SimpleResult, Request, Result}
+import play.api.mvc.{Request, Result}
 import be.objectify.deadbolt.core.models.Subject
 import scala.concurrent.Future
 
@@ -18,7 +18,7 @@ trait DeadboltHandler {
    *
    * @return an option possible containing a Result.
    */
-  def beforeAuthCheck[A](request: Request[A]): Option[Future[SimpleResult]]
+  def beforeAuthCheck[A](request: Request[A]): Option[Future[Result]]
 
   /**
    * Gets the current subject e.g. the current user.
@@ -32,7 +32,7 @@ trait DeadboltHandler {
    *
    * @return the action
    */
-  def onAuthFailure[A](request: Request[A]): Future[SimpleResult]
+  def onAuthFailure[A](request: Request[A]): Future[Result]
 
   /**
    * Gets the handler used for dealing with resources restricted to specific users/groups.

--- a/app/be/objectify/deadbolt/scala/views/dynamic.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/dynamic.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @if(be.objectify.deadbolt.scala.DeadboltViewSupport.viewDynamic(name, meta, handler, request)) {
 @body

--- a/app/be/objectify/deadbolt/scala/views/dynamicOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/dynamicOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => Html)(alternativeBody: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @if(be.objectify.deadbolt.scala.DeadboltViewSupport.viewDynamic(name, meta, handler, request)) {
 @body

--- a/app/be/objectify/deadbolt/scala/views/pattern.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/pattern.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/patternOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/patternOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => Html)(alternativeBody: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/restrict.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/restrict.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/restrictOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/restrictOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => Html)(alternativeBody: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectNotPresent.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectNotPresent.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectNotPresentOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectNotPresentOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => Html)(alternativeBody: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectPresent.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectPresent.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectPresentOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectPresentOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => Html)(alternativeBody: => Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,20 +1,23 @@
 import sbt._
 import Keys._
-import play.Project._
+import play.Play.autoImport._
+import PlayKeys._
 
 object ApplicationBuild extends Build {
 
   val appName         = "deadbolt-scala"
-  val appVersion      = "2.2.1-RC1"
+  val appVersion      = "2.3.0-RC1"
 
   val appDependencies = Seq(
     cache,
-    "be.objectify" %% "deadbolt-core" % "2.2.1-RC1"
+    "be.objectify" %% "deadbolt-core" % "2.3.0-RC1"
   )
 
 
-  val main = play.Project(appName, appVersion, appDependencies).settings(
+  val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
     organization := "be.objectify",
+    version := appVersion,
+    libraryDependencies ++= appDependencies,
     resolvers += Resolver.url("Objectify Play Repository", url("http://schaloner.github.com/releases/"))(Resolver.ivyStylePatterns),
     resolvers += Resolver.url("Objectify Play Snapshot Repository", url("http://schaloner.github.com/snapshots/"))(Resolver.ivyStylePatterns)
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.2.1"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.3.0"))


### PR DESCRIPTION
There was changed nothing special:
- use `Result` instead of `SimpleResult` (which since `2.3` became a type alias for `Result`)
- use `play.twirl.api.Html` instead of `Html` (which since `2.3` became a type alias for `play.twirl.api.Htm`)

And if first case is not important, second case ruins binary compatibility.

_Note_: this pull request depends on version of `deadbolt-2-core` being `2.3.0-RC1`, though it also works fine with previous version. Please tell me if I need to rollback to `2.2.1-RC1` version of `deadbolt-2-core`. Thanks.
