### PR TITLE
updated for using cached subject from controller

### DIFF
--- a/app/be/objectify/deadbolt/scala/AuthenticatedRequest.scala
+++ b/app/be/objectify/deadbolt/scala/AuthenticatedRequest.scala
@@ -1,0 +1,29 @@
+package be.objectify.deadbolt.scala
+
+import be.objectify.deadbolt.core.models.Subject
+import play.api.mvc.Request
+
+/**
+ * Wrapping request with subject
+ * @tparam A
+ */
+trait AuthenticatedRequest[+A] extends Request[A] {
+  val subject: Option[Subject]
+}
+
+object AuthenticatedRequest {
+  def apply[A](r: Request[A], s: Option[Subject]) = new AuthenticatedRequest[A] {
+    def id = r.id
+    def tags = r.tags
+    def uri = r.uri
+    def path = r.path
+    def method = r.method
+    def version = r.version
+    def queryString = r.queryString
+    def headers = r.headers
+    def secure = r.secure
+    lazy val remoteAddress = r.remoteAddress
+    val body = r.body
+    val subject = s
+  }
+}

--- a/app/be/objectify/deadbolt/scala/DeadboltActionBuilders.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltActionBuilders.scala
@@ -13,10 +13,6 @@ object DeadboltActionBuilders {
 
     def apply(roles: String*) = RestrictActionBuilder(roles:_*)
 
-    def async(roles: String*)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = RestrictActionBuilder(roles: _*).async(block)(deadbloltHandler)
-    def async(roles: String*)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = RestrictActionBuilder(roles: _*).async(block)(deadbloltHandler)
-    def async[A](roles: String*)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = RestrictActionBuilder(roles: _*).async(bodyParser)(block)(deadbloltHandler)
-
     case class RestrictActionBuilder(roles: String*) extends DeadboltActionBuilder {
 
       override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
@@ -28,14 +24,6 @@ object DeadboltActionBuilders {
   object DynamicAction extends DeadboltActions {
 
     def apply(name: String, meta: String = "") = DynamicActionBuilder(name, meta)
-
-    def async(name: String)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler):Action[AnyContent] = DynamicActionBuilder(name, "").async(block)(deadbloltHandler)
-    def async(name: String)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, "").async(block)(deadbloltHandler)
-    def async[A](name: String)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, "").async(bodyParser)(block)(deadbloltHandler)
-
-    def async(name: String, meta: String)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, meta).async(block)(deadbloltHandler)
-    def async(name: String, meta: String)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, meta).async(block)(deadbloltHandler)
-    def async[A](name: String, meta: String)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, meta).async(bodyParser)(block)(deadbloltHandler)
 
     case class DynamicActionBuilder(name: String, meta: String = "") extends DeadboltActionBuilder {
 
@@ -49,10 +37,6 @@ object DeadboltActionBuilders {
 
     def apply(value: String, patternType: PatternType) = PatternActionBuilder(value, patternType)
 
-    def async(value: String, patternType: PatternType)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = PatternActionBuilder(value, patternType).async(block)(deadbloltHandler)
-    def async(value: String, patternType: PatternType)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = PatternActionBuilder(value, patternType).async(block)(deadbloltHandler)
-    def async[A](value: String, patternType: PatternType)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = PatternActionBuilder(value, patternType).async(bodyParser)(block)(deadbloltHandler)
-
     case class PatternActionBuilder(value: String, patternType: PatternType) extends DeadboltActionBuilder {
 
       override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
@@ -65,10 +49,6 @@ object DeadboltActionBuilders {
 
     def apply = SubjectPresentActionBuilder()
 
-    def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectPresentActionBuilder().async(block)(deadbloltHandler)
-    def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectPresentActionBuilder().async(block)(deadbloltHandler)
-    def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectPresentActionBuilder().async(bodyParser)(block)(deadbloltHandler)
-
     case class SubjectPresentActionBuilder() extends DeadboltActionBuilder {
 
       override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
@@ -80,10 +60,6 @@ object DeadboltActionBuilders {
   object SubjectNotPresentAction extends DeadboltActions {
 
     def apply = SubjectNotPresentActionBuilder()
-
-    def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectNotPresentActionBuilder().async(block)(deadbloltHandler)
-    def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectNotPresentActionBuilder().async(block)(deadbloltHandler)
-    def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectNotPresentActionBuilder().async(bodyParser)(block)(deadbloltHandler)
 
     case class SubjectNotPresentActionBuilder() extends DeadboltActionBuilder {
 
@@ -101,9 +77,9 @@ object DeadboltActionBuilders {
       Future.successful(block(req))
     }
 
-    private[DeadboltActionBuilders] def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler): Action[AnyContent] = async( _ => block)(deadbloltHandler)
-    private[DeadboltActionBuilders] def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = async(BodyParsers.parse.anyContent)(block)(deadboltHandler)
-    private[DeadboltActionBuilders] def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[A]
+    def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler): Action[AnyContent] = async( _ => block)(deadbloltHandler)
+    def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = async(BodyParsers.parse.anyContent)(block)(deadboltHandler)
+    def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[A]
 
     def withHandler(deadboltHandler: DeadboltHandler) = new {
       def apply(block: => Result): Action[AnyContent] =

--- a/app/be/objectify/deadbolt/scala/DeadboltActionBuilders.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltActionBuilders.scala
@@ -1,5 +1,6 @@
 package be.objectify.deadbolt.scala
 
+import scala.concurrent.Future
 import play.api.mvc._
 import be.objectify.deadbolt.core.PatternType
 
@@ -12,9 +13,13 @@ object DeadboltActionBuilders {
 
     def apply(roles: String*) = RestrictActionBuilder(roles:_*)
 
+    def async(roles: String*)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = RestrictActionBuilder(roles: _*).async(block)(deadbloltHandler)
+    def async(roles: String*)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = RestrictActionBuilder(roles: _*).async(block)(deadbloltHandler)
+    def async[A](roles: String*)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = RestrictActionBuilder(roles: _*).async(bodyParser)(block)(deadbloltHandler)
+
     case class RestrictActionBuilder(roles: String*) extends DeadboltActionBuilder {
 
-      override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[A] =
+      override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
         Restrict(roles.toArray, deadboltHandler)(bodyParser)(block)
 
     }
@@ -24,9 +29,17 @@ object DeadboltActionBuilders {
 
     def apply(name: String, meta: String = "") = DynamicActionBuilder(name, meta)
 
+    def async(name: String)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler):Action[AnyContent] = DynamicActionBuilder(name, "").async(block)(deadbloltHandler)
+    def async(name: String)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, "").async(block)(deadbloltHandler)
+    def async[A](name: String)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, "").async(bodyParser)(block)(deadbloltHandler)
+
+    def async(name: String, meta: String)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, meta).async(block)(deadbloltHandler)
+    def async(name: String, meta: String)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, meta).async(block)(deadbloltHandler)
+    def async[A](name: String, meta: String)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = DynamicActionBuilder(name, meta).async(bodyParser)(block)(deadbloltHandler)
+
     case class DynamicActionBuilder(name: String, meta: String = "") extends DeadboltActionBuilder {
 
-      override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[A] =
+      override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
         Dynamic(name, meta, deadboltHandler)(bodyParser)(block)
 
     }
@@ -36,9 +49,13 @@ object DeadboltActionBuilders {
 
     def apply(value: String, patternType: PatternType) = PatternActionBuilder(value, patternType)
 
+    def async(value: String, patternType: PatternType)(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = PatternActionBuilder(value, patternType).async(block)(deadbloltHandler)
+    def async(value: String, patternType: PatternType)(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = PatternActionBuilder(value, patternType).async(block)(deadbloltHandler)
+    def async[A](value: String, patternType: PatternType)(bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = PatternActionBuilder(value, patternType).async(bodyParser)(block)(deadbloltHandler)
+
     case class PatternActionBuilder(value: String, patternType: PatternType) extends DeadboltActionBuilder {
 
-      override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[A] =
+      override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
         Pattern(value, patternType, deadboltHandler)(bodyParser)(block)
 
     }
@@ -46,11 +63,15 @@ object DeadboltActionBuilders {
 
   object SubjectPresentAction extends DeadboltActions {
 
-    def apply() = SubjectPresentActionBuilder()
+    def apply = SubjectPresentActionBuilder()
+
+    def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectPresentActionBuilder().async(block)(deadbloltHandler)
+    def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectPresentActionBuilder().async(block)(deadbloltHandler)
+    def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectPresentActionBuilder().async(bodyParser)(block)(deadbloltHandler)
 
     case class SubjectPresentActionBuilder() extends DeadboltActionBuilder {
 
-      override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[A] =
+      override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
         SubjectPresent(deadboltHandler)(bodyParser)(block)
 
     }
@@ -58,11 +79,15 @@ object DeadboltActionBuilders {
 
   object SubjectNotPresentAction extends DeadboltActions {
 
-    def apply() = SubjectNotPresentActionBuilder()
+    def apply = SubjectNotPresentActionBuilder()
+
+    def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectNotPresentActionBuilder().async(block)(deadbloltHandler)
+    def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectNotPresentActionBuilder().async(block)(deadbloltHandler)
+    def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadbloltHandler: DeadboltHandler) = SubjectNotPresentActionBuilder().async(bodyParser)(block)(deadbloltHandler)
 
     case class SubjectNotPresentActionBuilder() extends DeadboltActionBuilder {
 
-      override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[A] =
+      override def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler) : Action[A] =
         SubjectNotPresent(deadboltHandler)(bodyParser)(block)
     }
 
@@ -72,7 +97,13 @@ object DeadboltActionBuilders {
 
     def apply(block: => Result)(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = apply( _ => block)(deadboltHandler)
     def apply(block: AuthenticatedRequest[AnyContent] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[AnyContent] = apply(BodyParsers.parse.anyContent)(block)(deadboltHandler)
-    def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler) : Action[A]
+    def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Result)(implicit deadboltHandler: DeadboltHandler): Action[A] = async(bodyParser) { req: AuthenticatedRequest[A] =>
+      Future.successful(block(req))
+    }
+
+    private[DeadboltActionBuilders] def async(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler): Action[AnyContent] = async( _ => block)(deadbloltHandler)
+    private[DeadboltActionBuilders] def async(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = async(BodyParsers.parse.anyContent)(block)(deadboltHandler)
+    private[DeadboltActionBuilders] def async[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[A]
 
     def withHandler(deadboltHandler: DeadboltHandler) = new {
       def apply(block: => Result): Action[AnyContent] =

--- a/app/be/objectify/deadbolt/scala/DeadboltActions.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltActions.scala
@@ -179,7 +179,7 @@ trait DeadboltActions extends Results with BodyParsers {
             case Some(result) => result
             case _ => {
               deadboltHandler.getSubject(authRequest) match {
-                case Some(handler) => Future.successful(block(authRequest))
+                case Some(subject) => Future.successful(block( AuthenticatedRequest(authRequest, Some(subject)) ))
                 case None => deadboltHandler.onAuthFailure(authRequest)
               }
             }

--- a/app/be/objectify/deadbolt/scala/DeadboltActions.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltActions.scala
@@ -1,12 +1,13 @@
 package be.objectify.deadbolt.scala
 
-import play.api.mvc.{Action, Results, BodyParsers}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.mvc.{Action, Results, BodyParsers, BodyParser, Result}
 import play.cache.Cache
 import be.objectify.deadbolt.core.{DeadboltAnalyzer, PatternType}
 import be.objectify.deadbolt.core.models.Subject
 import java.util.concurrent.Callable
 import java.util.regex.Pattern
-
 
 /**
  * Controller-level authorisations for Scala controllers.
@@ -25,9 +26,11 @@ trait DeadboltActions extends Results with BodyParsers {
    * @return
    */
   def Restrict[A](roleNames: Array[String],
-                  deadboltHandler: DeadboltHandler)(action: Action[A]): Action[A] = {
+                  deadboltHandler: DeadboltHandler)
+                 (bodyParser: BodyParser[A])
+                 (block: AuthenticatedRequest[A] => Result): Action[A] = {
     Restrict[A](List(roleNames),
-                deadboltHandler)(action)
+                deadboltHandler)(bodyParser)(block)
   }
 
   /**
@@ -42,8 +45,9 @@ trait DeadboltActions extends Results with BodyParsers {
    */
   def Restrict[A](roleGroups: List[Array[String]],
                   deadboltHandler: DeadboltHandler)
-                  (action: Action[A]): Action[A] = {
-    Action.async(action.parser) { implicit request =>
+                 (bodyParser: BodyParser[A])
+                 (block: AuthenticatedRequest[A] => Result): Action[A] = {
+    SubjectActionBuilder(None).async(bodyParser){ authRequest =>
 
       def check(subject: Subject, current: Array[String], remaining: List[Array[String]]): Boolean = {
         if (DeadboltAnalyzer.checkRole(subject, current)) true
@@ -51,17 +55,18 @@ trait DeadboltActions extends Results with BodyParsers {
         else check(subject, remaining.head, remaining.tail)
       }
 
-      deadboltHandler.beforeAuthCheck(request) match {
+      deadboltHandler.beforeAuthCheck(authRequest) match {
           case Some(result) => result
           case _ => {
-            if (roleGroups.isEmpty) deadboltHandler.onAuthFailure(request)
+            if (roleGroups.isEmpty) deadboltHandler.onAuthFailure(authRequest)
             else {
-              deadboltHandler.getSubject(request) match {
+              deadboltHandler.getSubject(authRequest) match {
                 case Some(subject) => {
-                  if (check(subject, roleGroups.head, roleGroups.tail)) action(request)
-                  else deadboltHandler.onAuthFailure(request)
+                  if (check(subject, roleGroups.head, roleGroups.tail))
+                    Future.successful( block( AuthenticatedRequest(authRequest, Some(subject)) ) )
+                  else deadboltHandler.onAuthFailure(authRequest)
                 }
-                case _ => deadboltHandler.onAuthFailure(request)
+                case _ => deadboltHandler.onAuthFailure(authRequest)
               }
             }
           }
@@ -81,15 +86,17 @@ trait DeadboltActions extends Results with BodyParsers {
   def Dynamic[A](name: String,
                  meta: String = "",
                  deadboltHandler: DeadboltHandler)
-                (action: Action[A]): Action[A] = {
-    Action.async(action.parser) { implicit request =>
-      deadboltHandler.beforeAuthCheck(request) match {
+                (bodyParser: BodyParser[A])
+                (block: AuthenticatedRequest[A] => Result): Action[A] = {
+    SubjectActionBuilder(None).async(bodyParser) { authRequest =>
+      deadboltHandler.beforeAuthCheck(authRequest) match {
           case Some(result) => result
           case _ => {
-            deadboltHandler.getDynamicResourceHandler(request) match {
+            deadboltHandler.getDynamicResourceHandler(authRequest) match {
               case Some(dynamicHandler) => {
-                if (dynamicHandler.isAllowed(name, meta, deadboltHandler, request)) action(request)
-                else deadboltHandler.onAuthFailure(request)
+                if (dynamicHandler.isAllowed(name, meta, deadboltHandler, authRequest))
+                  Future.successful( block(authRequest) )
+                else deadboltHandler.onAuthFailure(authRequest)
               }
               case None =>
                 throw new RuntimeException("A dynamic resource is specified but no dynamic resource handler is provided")
@@ -111,7 +118,8 @@ trait DeadboltActions extends Results with BodyParsers {
   def Pattern[A](value: String,
                  patternType: PatternType,
                  deadboltHandler: DeadboltHandler)
-                (action: Action[A]): Action[A] = {
+                (bodyParser: BodyParser[A])
+                (block: AuthenticatedRequest[A] => Result): Action[A] = {
 
     def getPattern(patternValue: String): Pattern =
       Cache.getOrElse("Deadbolt." + patternValue,
@@ -120,29 +128,28 @@ trait DeadboltActions extends Results with BodyParsers {
         },
         0)
 
-    Action.async(action.parser) {
-      implicit request =>
-        deadboltHandler.beforeAuthCheck(request) match {
+    SubjectActionBuilder(None).async(bodyParser) {
+      implicit authRequest =>
+        deadboltHandler.beforeAuthCheck(authRequest) match {
           case Some(result) => result
           case _ => {
-            val maySubject = deadboltHandler.getSubject(request)
-            maySubject match {
-              case None => deadboltHandler.onAuthFailure(request)
+            deadboltHandler.getSubject(authRequest) match {
+              case None => deadboltHandler.onAuthFailure(authRequest)
               case Some(subject) => {
                 patternType match {
                   case PatternType.EQUALITY => {
-                    if (DeadboltAnalyzer.checkPatternEquality(subject, value)) action(request)
-                    else deadboltHandler.onAuthFailure(request)
+                    if (DeadboltAnalyzer.checkPatternEquality(subject, value)) Future.successful(block(authRequest))
+                    else deadboltHandler.onAuthFailure(authRequest)
                   }
                   case PatternType.REGEX => {
-                    if (DeadboltAnalyzer.checkRegexPattern(subject, getPattern(value))) action(request)
-                    else deadboltHandler.onAuthFailure(request)
+                    if (DeadboltAnalyzer.checkRegexPattern(subject, getPattern(value))) Future.successful(block(authRequest))
+                    else deadboltHandler.onAuthFailure(authRequest)
                   }
                   case PatternType.CUSTOM => {
-                    deadboltHandler.getDynamicResourceHandler(request) match {
+                    deadboltHandler.getDynamicResourceHandler(authRequest) match {
                       case Some(dynamicHandler) => {
-                        if (dynamicHandler.checkPermission(value, deadboltHandler, request)) action(request)
-                        else deadboltHandler.onAuthFailure(request)
+                        if (dynamicHandler.checkPermission(value, deadboltHandler, authRequest)) Future.successful(block(authRequest))
+                        else deadboltHandler.onAuthFailure(authRequest)
                       }
                       case None =>
                         throw new RuntimeException("A custom pattern is specified but no dynamic resource handler is provided")
@@ -164,14 +171,16 @@ trait DeadboltActions extends Results with BodyParsers {
    * @tparam A
    * @return
    */
-  def SubjectPresent[A](deadboltHandler: DeadboltHandler)(action: Action[A]): Action[A] = {
-    Action.async(action.parser) { implicit request =>
-      deadboltHandler.beforeAuthCheck(request) match {
+  def SubjectPresent[A](deadboltHandler: DeadboltHandler)
+                       (bodyParser: BodyParser[A])
+                       (block: AuthenticatedRequest[A] => Result): Action[A] = {
+    SubjectActionBuilder(None).async(bodyParser) { authRequest =>
+      deadboltHandler.beforeAuthCheck(authRequest) match {
             case Some(result) => result
             case _ => {
-              deadboltHandler.getSubject(request) match {
-                case Some(handler) => action(request)
-                case None => deadboltHandler.onAuthFailure(request)
+              deadboltHandler.getSubject(authRequest) match {
+                case Some(handler) => Future.successful(block(authRequest))
+                case None => deadboltHandler.onAuthFailure(authRequest)
               }
             }
           }
@@ -186,14 +195,16 @@ trait DeadboltActions extends Results with BodyParsers {
    * @tparam A
    * @return
    */
-  def SubjectNotPresent[A](deadboltHandler: DeadboltHandler)(action: Action[A]): Action[A] = {
-    Action.async(action.parser) { implicit request =>
-      deadboltHandler.beforeAuthCheck(request) match {
+  def SubjectNotPresent[A](deadboltHandler: DeadboltHandler)
+                          (bodyParser: BodyParser[A])
+                          (block: AuthenticatedRequest[A] => Result): Action[A] = {
+    SubjectActionBuilder(None).async(bodyParser) { authRequest =>
+      deadboltHandler.beforeAuthCheck(authRequest) match {
             case Some(result) => result
             case _ => {
-              deadboltHandler.getSubject(request) match {
-                case Some(subject) => deadboltHandler.onAuthFailure(request)
-                case None => action(request)
+              deadboltHandler.getSubject(authRequest) match {
+                case Some(subject) => deadboltHandler.onAuthFailure(authRequest)
+                case None => Future.successful( block(authRequest) )
               }
             }
           }

--- a/app/be/objectify/deadbolt/scala/DeadboltHandler.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltHandler.scala
@@ -25,7 +25,7 @@ trait DeadboltHandler {
    *
    * @return an option containing the current subject
    */
-  def getSubject[A](request: Request[A]): Option[Subject]
+  def getSubject[A](request: AuthenticatedRequest[A]): Option[Subject]
 
   /**
    * Invoked when an authorisation failure is detected for the request.

--- a/app/be/objectify/deadbolt/scala/DeadboltViewSupport.scala
+++ b/app/be/objectify/deadbolt/scala/DeadboltViewSupport.scala
@@ -23,7 +23,7 @@ object  DeadboltViewSupport {
    */
   def viewRestrict(roles: List[Array[String]],
                    deadboltHandler: DeadboltHandler,
-                   request: Request[Any]): Boolean = {
+                   request: AuthenticatedRequest[Any]): Boolean = {
     def check(subject: Subject, current: Array[String], remaining: List[Array[String]]): Boolean = {
       if (DeadboltAnalyzer.checkRole(subject, current)) true
       else if (remaining.isEmpty) false
@@ -49,7 +49,7 @@ object  DeadboltViewSupport {
   def viewDynamic(name: String,
                   meta: String,
                   deadboltHandler: DeadboltHandler,
-                  request: Request[Any]): Boolean = {
+                  request: AuthenticatedRequest[Any]): Boolean = {
     val resourceHandler = deadboltHandler.getDynamicResourceHandler(request)
     if (resourceHandler.isDefined) resourceHandler.get.isAllowed(name, meta, deadboltHandler, request)
     else throw new RuntimeException("A dynamic resource is specified but no dynamic resource handler is provided")
@@ -66,7 +66,7 @@ object  DeadboltViewSupport {
   def viewPattern(value: String,
                   patternType: PatternType,
                   deadboltHandler: DeadboltHandler,
-                  request: Request[Any]): Boolean = {
+                  request: AuthenticatedRequest[Any]): Boolean = {
     def getPattern(patternValue: String): Pattern =
       Cache.getOrElse("Deadbolt." + patternValue,
                       new Callable[Pattern]{

--- a/app/be/objectify/deadbolt/scala/SubjectAction.scala
+++ b/app/be/objectify/deadbolt/scala/SubjectAction.scala
@@ -1,0 +1,23 @@
+package be.objectify.deadbolt.scala
+
+import scala.concurrent.Future
+import be.objectify.deadbolt.core.models.Subject
+import play.api.mvc.{ActionTransformer, ActionBuilder, Request}
+
+object SubjectActionBuilder {
+
+  def apply(subject: Option[Subject]) = AuthenticatedActionBuilder(subject)
+
+  case class AuthenticatedActionBuilder(subject: Option[Subject]) extends SubjectActionBuilder
+
+}
+
+trait SubjectActionBuilder extends ActionBuilder[AuthenticatedRequest] with ActionTransformer[Request, AuthenticatedRequest] {
+
+  def subject: Option[Subject]
+
+  def transform[A](request: Request[A]) = Future.successful {
+    AuthenticatedRequest(request, subject)
+  }
+
+}

--- a/app/be/objectify/deadbolt/scala/views/dynamic.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/dynamic.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @if(be.objectify.deadbolt.scala.DeadboltViewSupport.viewDynamic(name, meta, handler, request)) {
 @body

--- a/app/be/objectify/deadbolt/scala/views/dynamicOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/dynamicOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, name: String, meta: String = null)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @if(be.objectify.deadbolt.scala.DeadboltViewSupport.viewDynamic(name, meta, handler, request)) {
 @body

--- a/app/be/objectify/deadbolt/scala/views/pattern.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/pattern.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/patternOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/patternOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, value: String, patternType: be.objectify.deadbolt.core.PatternType = be.objectify.deadbolt.core.PatternType.EQUALITY)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/restrict.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/restrict.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/restrictOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/restrictOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler, roles: List[Array[String]])(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectNotPresent.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectNotPresent.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectNotPresentOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectNotPresentOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectPresent.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectPresent.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 

--- a/app/be/objectify/deadbolt/scala/views/subjectPresentOr.scala.html
+++ b/app/be/objectify/deadbolt/scala/views/subjectPresentOr.scala.html
@@ -1,4 +1,4 @@
-@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: Request[Any])
+@(handler: be.objectify.deadbolt.scala.DeadboltHandler)(body: => play.twirl.api.Html)(alternativeBody: => play.twirl.api.Html)(implicit request: be.objectify.deadbolt.scala.AuthenticatedRequest[Any])
 
 @import scala.collection.JavaConversions._
 


### PR DESCRIPTION
I have updated API for DeadboltActions. Authentication is a one-time process (for each request) – it rarely needs to be done multiple times (only inside templates).

How do you like this realization? I suggest using ActionBuilders for creating constraints. So instead:

```
 def restrictOne = Restrict(Array("foo"), new MyDeadboltHandler) {
   Action {
     Ok(accessOk())
  }
}
```

using

```
def restrictOne = RestrictAction("foo"){ authRequest =>
   // authRequest.subject accessible here
   Ok(accessOk())
}
```

DeadboltHandler example:

```
...
def getSubject[A](request: AuthenticatedRequest[A]): Option[Subject] = request.subject.orElse {
    getUserFromDB(request)
}
...
```
for not using cached user, just not using `request.subject`