### PR TITLE
WithAuthRequest

### DIFF
--- a/code/app/be/objectify/deadbolt/scala/ActionBuilders.scala
+++ b/code/app/be/objectify/deadbolt/scala/ActionBuilders.scala
@@ -85,6 +85,17 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
     }
   }
 
+  object WithAuthRequestAction {
+
+    def apply(): WithAuthRequestAction.WithAuthRequestActionBuilder = WithAuthRequestActionBuilder()
+
+    case class WithAuthRequestActionBuilder() extends DeadboltActionBuilder {
+
+      override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
+        deadboltActions.WithAuthRequest(handler)(bodyParser)(block)
+    }
+  }
+
   trait DeadboltActionBuilder {
 
     def apply(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler): Action[AnyContent] = apply( _ => block)(deadbloltHandler)

--- a/code/app/be/objectify/deadbolt/scala/DeadboltActions.scala
+++ b/code/app/be/objectify/deadbolt/scala/DeadboltActions.scala
@@ -184,6 +184,13 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
                                       else handler.onAuthFailure(authRequest)
                            )(ec))
 
+  def WithAuthRequest[A](handler: DeadboltHandler = handlers())
+                        (bodyParser: BodyParser[A] = parse.anyContent)
+                        (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
+    SubjectActionBuilder(None).async(bodyParser) { authRequest =>
+      block(authRequest)
+    }
+
   /**
     *
     * @param handler the handler to use for constraint testing


### PR DESCRIPTION
Support for creating actions with AuthenticatedRequest that don't have any controller-level constraints.  This makes it easier to use template constraints.