### PR TITLE
Fixed compile warnings and tests in DeadboltActions

### DIFF
--- a/code/app/be/objectify/deadbolt/scala/ActionBuilders.scala
+++ b/code/app/be/objectify/deadbolt/scala/ActionBuilders.scala
@@ -31,10 +31,14 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object RestrictAction {
 
-    def apply(roles: RoleGroups): RestrictAction.RestrictActionBuilder = RestrictActionBuilder(roles)
-    def apply(roles: String*): RestrictAction.RestrictActionBuilder = RestrictActionBuilder(List(roles.toArray))
+    def apply(roles: RoleGroups)(implicit bodyParsers: PlayBodyParsers): RestrictAction.RestrictActionBuilder =
+      RestrictActionBuilder(roles)
+    def apply(roles: String*)(implicit bodyParsers: PlayBodyParsers): RestrictAction.RestrictActionBuilder =
+      RestrictActionBuilder(List(roles.toArray))
 
-    case class RestrictActionBuilder(roles: RoleGroups) extends DeadboltActionBuilder {
+    case class RestrictActionBuilder(roles: RoleGroups)
+                                    (implicit val bodyParsers: PlayBodyParsers)
+      extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.Restrict(roles, handler)(bodyParser)(block)
@@ -43,9 +47,12 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object RoleBasedPermissionsAction {
 
-    def apply(roleName: String): RoleBasedPermissionsAction.RoleBasedPermissionsActionBuilder = RoleBasedPermissionsActionBuilder(roleName)
+    def apply(roleName: String)(implicit bodyParsers: PlayBodyParsers): RoleBasedPermissionsAction.RoleBasedPermissionsActionBuilder =
+      RoleBasedPermissionsActionBuilder(roleName)
 
-    case class RoleBasedPermissionsActionBuilder(roleName: String) extends DeadboltActionBuilder {
+    case class RoleBasedPermissionsActionBuilder(roleName: String)
+                                                (implicit val bodyParsers: PlayBodyParsers)
+      extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.RoleBasedPermissions(roleName, handler)(bodyParser)(block)
@@ -54,9 +61,12 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object DynamicAction {
 
-    def apply(name: String, meta: Option[Any] = None): DynamicAction.DynamicActionBuilder = DynamicActionBuilder(name, meta)
+    def apply(name: String, meta: Option[Any] = None)(implicit bodyParsers: PlayBodyParsers): DynamicAction.DynamicActionBuilder =
+      DynamicActionBuilder(name, meta)
 
-    case class DynamicActionBuilder(name: String, meta: Option[Any] = None) extends DeadboltActionBuilder {
+    case class DynamicActionBuilder(name: String, meta: Option[Any] = None)
+                                   (implicit val bodyParsers: PlayBodyParsers)
+      extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.Dynamic(name, meta, handler)(bodyParser)(block)
@@ -65,9 +75,15 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object PatternAction {
 
-    def apply(value: String, patternType: PatternType, meta: Option[Any] = None, invert: Boolean = false): PatternAction.PatternActionBuilder = PatternActionBuilder(value, patternType, meta, invert)
+    def apply(value: String, patternType: PatternType, meta: Option[Any] = None, invert: Boolean = false)(implicit bodyParsers: PlayBodyParsers): PatternAction.PatternActionBuilder =
+      PatternActionBuilder(value, patternType, meta, invert)
 
-    case class PatternActionBuilder(value: String, patternType: PatternType = PatternType.EQUALITY, meta: Option[Any] = None, invert: Boolean = false) extends DeadboltActionBuilder {
+    case class PatternActionBuilder(value: String,
+                                    patternType: PatternType = PatternType.EQUALITY,
+                                    meta: Option[Any] = None,
+                                    invert: Boolean = false)
+                                   (implicit val bodyParsers: PlayBodyParsers)
+      extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.Pattern(value, patternType, meta, handler, invert)(bodyParser)(block)
@@ -76,9 +92,10 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object SubjectPresentAction {
 
-    def apply(): SubjectPresentAction.SubjectPresentActionBuilder = SubjectPresentActionBuilder()
+    def apply()(implicit bodyParsers: PlayBodyParsers): SubjectPresentAction.SubjectPresentActionBuilder =
+      SubjectPresentActionBuilder()
 
-    case class SubjectPresentActionBuilder() extends DeadboltActionBuilder {
+    case class SubjectPresentActionBuilder()(implicit val bodyParsers: PlayBodyParsers) extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.SubjectPresent(handler)(bodyParser)(block)
@@ -87,9 +104,11 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object SubjectNotPresentAction {
 
-    def apply(): SubjectNotPresentAction.SubjectNotPresentActionBuilder = SubjectNotPresentActionBuilder()
+    def apply()(implicit bodyParsers: PlayBodyParsers): SubjectNotPresentAction.SubjectNotPresentActionBuilder =
+      SubjectNotPresentActionBuilder()
 
-    case class SubjectNotPresentActionBuilder() extends DeadboltActionBuilder {
+    case class SubjectNotPresentActionBuilder()(implicit val bodyParsers: PlayBodyParsers)
+      extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.SubjectNotPresent(handler)(bodyParser)(block)
@@ -98,9 +117,11 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   object WithAuthRequestAction {
 
-    def apply(): WithAuthRequestAction.WithAuthRequestActionBuilder = WithAuthRequestActionBuilder()
+    def apply()(implicit bodyParsers: PlayBodyParsers): WithAuthRequestAction.WithAuthRequestActionBuilder =
+      WithAuthRequestActionBuilder()
 
-    case class WithAuthRequestActionBuilder() extends DeadboltActionBuilder {
+    case class WithAuthRequestActionBuilder()(implicit val bodyParsers: PlayBodyParsers)
+      extends DeadboltActionBuilder {
 
       override def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler) : Action[A] =
         deadboltActions.WithAuthRequest(handler)(bodyParser)(block)
@@ -109,8 +130,10 @@ class ActionBuilders @Inject() (deadboltActions: DeadboltActions, handlers: Hand
 
   trait DeadboltActionBuilder {
 
-    def apply(block: => Future[Result])(implicit deadbloltHandler: DeadboltHandler): Action[AnyContent] = apply( _ => block)(deadbloltHandler)
-    def apply(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = apply(BodyParsers.parse.anyContent)(block)(deadboltHandler)
+    val bodyParsers: PlayBodyParsers
+
+    def apply(block: => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = apply(_ => block)(deadboltHandler)
+    def apply(block: AuthenticatedRequest[AnyContent] => Future[Result])(implicit deadboltHandler: DeadboltHandler): Action[AnyContent] = apply(bodyParsers.anyContent)(block)(deadboltHandler)
     def apply[A](bodyParser: BodyParser[A])(block: AuthenticatedRequest[A] => Future[Result])(implicit handler: DeadboltHandler): Action[A]
 
     def withHandler(deadboltHandler: DeadboltHandler) = new {

--- a/code/app/be/objectify/deadbolt/scala/DeadboltActions.scala
+++ b/code/app/be/objectify/deadbolt/scala/DeadboltActions.scala
@@ -35,7 +35,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
                                 ecProvider: ExecutionContextProvider,
                                 logic: ConstraintLogic,
                                 bodyParsers: PlayBodyParsers)
-  extends Results with BodyParsers {
+  extends Results {
 
   private val ec = ecProvider.get()
 
@@ -67,7 +67,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
     */
   def Restrict[A](roleGroups: RoleGroups,
     handler: DeadboltHandler = handlers())
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -93,7 +93,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
     */
   def RoleBasedPermissions[A](roleName: String,
     handler: DeadboltHandler = handlers())
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -119,7 +119,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
   def Dynamic[A](name: String,
     meta: Option[Any] = None,
     handler: DeadboltHandler = handlers())
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -148,7 +148,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
     meta: Option[Any] = None,
     handler: DeadboltHandler = handlers(),
     invert: Boolean = false)
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -173,7 +173,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
     * @return the action to take
     */
   def SubjectPresent[A](handler: DeadboltHandler = handlers())
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -193,7 +193,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
     * @return the action to take
     */
   def SubjectNotPresent[A](handler: DeadboltHandler = handlers())
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -214,7 +214,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
     */
   def Composite[A](handler: DeadboltHandler = handlers(),
     constraint: Constraint[A])
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     execute(handler,
       bodyParser,
@@ -231,7 +231,7 @@ class DeadboltActions @Inject()(analyzer: StaticConstraintAnalyzer,
       }(ec))
 
   def WithAuthRequest[A](handler: DeadboltHandler = handlers())
-    (bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
+    (bodyParser: BodyParser[A] = bodyParsers.anyContent)
     (block: AuthenticatedRequest[A] => Future[Result]): Action[A] =
     SubjectActionBuilder(None, ec, bodyParsers.anyContent).async(bodyParser) { authRequest =>
       handler.getSubject(authRequest).flatMap{ maybeSubject =>

--- a/code/test/be/objectify/deadbolt/scala/DeadboltActionsTest.scala
+++ b/code/test/be/objectify/deadbolt/scala/DeadboltActionsTest.scala
@@ -60,11 +60,11 @@ object DeadboltActionsTest extends PlaySpecification with Mockito {
   "composite" should {
     "propagate the authorized request when" >> {
       "a subject is present" >> {
-        val result: Future[Result] = deadbolt(handler(Option(User()))).Composite(constraint = composite.SubjectPresent())()((ar: AuthenticatedRequest[AnyContent]) => Future.successful(if (ar.subject.isDefined) Results.Ok("ok") else Results.Unauthorized("no user"))).apply(request(None))
+        val result: Future[Result] = deadbolt(handler(Option(User()))).Composite(constraint = composite.SubjectPresent())()(ar => Future.successful(if (ar.subject.isDefined) Results.Ok("ok") else Results.Unauthorized("no user"))).apply(request(None))
         await(result).header.status should beEqualTo(200)
       }
       "no subject is present" >> {
-        val result: Future[Result] = deadbolt(handler(None)).Composite(constraint = composite.SubjectNotPresent())()((ar: AuthenticatedRequest[AnyContent]) => Future.successful(if (ar.subject.isDefined) Results.Ok("ok") else Results.Unauthorized("no user"))).apply(request(None))
+        val result: Future[Result] = deadbolt(handler(None)).Composite(constraint = composite.SubjectNotPresent())()(ar => Future.successful(if (ar.subject.isDefined) Results.Ok("ok") else Results.Unauthorized("no user"))).apply(request(None))
         await(result).header.status should beEqualTo(401)
       }
     }


### PR DESCRIPTION
Unfortunately I had to change some things in the tests to make this work. I had to make the request type explicit. So everyones `{ implicit request =>` will break. I'm looking into fixing this so that there's no need to have an explicit type.

```scala
(ar: AuthenticatedRequest[AnyContent])
```

I also don't like the cast here, I'm thinking this may be the cause of the above problem:

```scala
(bodyParser: BodyParser[A] = bodyParsers.anyContent.asInstanceOf[BodyParser[A]])
```