### PR TITLE
Disable unneeded Play plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val code = (project in file("code"))
     fork in Test := true,
 
     releasePublishArtifactsAction := PgpKeys.publishSigned.value
-  ).enablePlugins(PlayScala).disablePlugins(PlayFilters)
+  ).enablePlugins(PlayScala).disablePlugins(PlayFilters, PlayLogback, PlayAkkaHttpServer)
 
 lazy val `test-app` = (project in file("test-app"))
   .settings(


### PR DESCRIPTION
This avoids polluting the dependency tree with unnecessary dependencies, which cause downstream users of the library to import undesired dependencies.

Specifically, no longer includes the following as dependencies:
  * "com.typesafe.play" %% "play-akka-http-server" % PlayVersion
  * "com.typesafe.play" %% "play-logback" % PlayVersion